### PR TITLE
Signed Repositories

### DIFF
--- a/builder/kojid
+++ b/builder/kojid
@@ -4211,8 +4211,9 @@ class NewRepoTask(BaseTaskHandler):
         else:
             oldrepo = self.session.getRepo(tinfo['id'], state=koji.REPO_READY)
         subtasks = {}
+        opts = {'do_external': True, 'deltas': False}
         for arch in arches:
-            arglist = [repo_id, arch, oldrepo]
+            arglist = [repo_id, arch, oldrepo, opts]
             subtasks[arch] = self.session.host.subtask(method='createrepo',
                                                        arglist=arglist,
                                                        label=arch,
@@ -4238,7 +4239,7 @@ class CreaterepoTask(BaseTaskHandler):
     def getRepoPath(self, repo_id, tag):
         return self.pathinfo.repo(repo_id, tag)
 
-    def handler(self, repo_id, arch, oldrepo, do_external):
+    def handler(self, repo_id, arch, oldrepo, opts):
         #arch is the arch of the repo, not the task
         rinfo = self.session.repoInfo(repo_id, strict=True)
         if rinfo['state'] != koji.REPO_INIT:
@@ -4256,11 +4257,13 @@ class CreaterepoTask(BaseTaskHandler):
         pkglist = os.path.join(self.repodir, 'pkglist')
         if os.path.getsize(pkglist) == 0:
             pkglist = None
-        self.create_local_repo(rinfo, arch, pkglist, groupdata, oldrepo)
-
-        external_repos = self.session.getExternalRepoList(rinfo['tag_id'], event=rinfo['create_event'])
-        if external_repos and do_external:
-            self.merge_repos(external_repos, arch, groupdata)
+        self.create_local_repo(rinfo, arch, pkglist, groupdata, oldrepo,
+            opts['deltas'])
+        if opts['do_external']:
+            external_repos = self.session.getExternalRepoList(
+                rinfo['tag_id'], event=rinfo['create_event'])
+            if external_repos:
+                self.merge_repos(external_repos, arch, groupdata)
         elif pkglist is None:
             fo = file(os.path.join(self.datadir, "EMPTY_REPO"), 'w')
             fo.write("This repo is empty because its tag has no content for this arch\n")
@@ -4271,10 +4274,14 @@ class CreaterepoTask(BaseTaskHandler):
         for f in os.listdir(self.datadir):
             files.append(f)
             self.session.uploadWrapper('%s/%s' % (self.datadir, f), uploadpath, f)
-
+        if opts['deltas']:
+            ddir = os.path.join(self.outdir, 'drpms')
+            for f in os.listdir(ddir):
+                files.append(f)
+                self.session.uploadWrapper('%s/%s' % (ddir, f), uploadpath, f)
         return [uploadpath, files]
 
-    def create_local_repo(self, rinfo, arch, pkglist, groupdata, oldrepo):
+    def create_local_repo(self, rinfo, arch, pkglist, groupdata, oldrepo, drpms):
         koji.ensuredir(self.outdir)
         cmd = ['/usr/bin/createrepo', '-vd', '-o', self.outdir]
         if pkglist is not None:
@@ -4282,7 +4289,9 @@ class CreaterepoTask(BaseTaskHandler):
         if os.path.isfile(groupdata):
             cmd.extend(['-g', groupdata])
         #attempt to recycle repodata from last repo
-        if pkglist and oldrepo and self.options.createrepo_update:
+        if pkglist and oldrepo and self.options.createrepo_update and not drpms:
+            # signed repos overload the use of "oldrepo", so the conditional
+            # explicitly make sure this does not get executed with that on
             oldpath = self.pathinfo.repo(oldrepo['id'], rinfo['tag_name'])
             olddatadir = '%s/%s/repodata' % (oldpath, arch)
             if not os.path.isdir(olddatadir):
@@ -4297,6 +4306,11 @@ class CreaterepoTask(BaseTaskHandler):
                 cmd.append('--update')
                 if self.options.createrepo_skip_stat:
                     cmd.append('--skip-stat')
+        if drpms:
+            # generate delta-rpms
+            cmd.append('--deltas')
+            for repo in oldrepo:
+                cmd.extend(['--oldpackagedirs', repo])
         # note: we can't easily use a cachedir because we do not have write
         # permission. The good news is that with --update we won't need to
         # be scanning many rpms.
@@ -4352,8 +4366,15 @@ class NewSignedRepoTask(BaseTaskHandler):
             if os.path.isfile("%s/%s/pkglist" % (path, fn)):
                 arches.append(fn)
         subtasks = {}
+        if task_opts['delta']:
+            make_drpms = True
+            oldrepo = task_opts['delta']
+        else:
+            make_drpms = False
+            oldrepo = None
         for arch in arches:
-            arglist = [repo_id, arch, None, False] # no old repo or external
+            opts = {'do_external': False, 'deltas': make_drpms}
+            arglist = [repo_id, arch, oldrepo, opts]
             subtasks[arch] = self.session.host.subtask(
                 method='createsignedrepo', arglist=arglist, label=arch,
                 parent=self.id, arch='noarch')

--- a/builder/kojid
+++ b/builder/kojid
@@ -4394,7 +4394,7 @@ class NewSignedRepoTask(BaseTaskHandler):
                 upload, files, keypaths = results[subtasks[arch]]
                 self.session.host.signedRepoMove(
                     repo_id, upload, files, arch, keypaths)
-        self.session.host.repoDone(repo_id, data, expire=True, signed=True)
+        self.session.host.repoDone(repo_id, data, expire=False, signed=True)
         return 'Signed repository #%s successfully generated' % repo_id
 
 

--- a/builder/kojid
+++ b/builder/kojid
@@ -4343,8 +4343,7 @@ class NewSignedRepoTask(BaseTaskHandler):
     _taskWeight = 0.1
 
     def handler(self, tag, repo_id, task_opts):
-        # TODO: remember to use an event here
-        tinfo = self.session.getTag(tag, strict=True)
+        tinfo = self.session.getTag(tag, strict=True, event=task_opts['event'])
         path = koji.pathinfo.signedrepo(repo_id, tinfo['name'])
         if not os.path.isdir(path):
             raise koji.GenericError, "Repo directory missing: %s" % path
@@ -4365,7 +4364,7 @@ class NewSignedRepoTask(BaseTaskHandler):
             data[arch] = results[task_id]
             self.logger.debug("DEBUG: %r : %r " % (arch, data[arch],))
         self.session.host.repoDone(repo_id, data, expire=True, signed=True)
-        return repo_id
+        return repo_id, task_opts['event']
 
 
 class createSignedRepoTask(CreaterepoTask):

--- a/builder/kojid
+++ b/builder/kojid
@@ -4566,7 +4566,8 @@ enabled=1
         rc, errors = yumbase.resolveDeps()
         ml_needed = set()
         for f in yumbase.tsInfo.getMembers():
-            dep_path = os.path.join(mldir, os.path.basename(f.po.localPkg()))
+            bnp = os.path.basename(f.po.localPkg())
+            dep_path = os.path.join(mldir, bnp[0], bnp)
             ml_needed.add(dep_path)
             self.logger.debug("added %s" % dep_path)
             if not os.path.exists(dep_path):
@@ -4584,8 +4585,9 @@ enabled=1
         pkgwriter = open(self.pkglist, 'a')
         for ml_pkg in ml_needed:
             bnp = os.path.basename(ml_pkg)
-            pkgwriter.write(bnp + '\n')
-            os.symlink(ml_pkg, os.path.join(self.repodir, bnp))
+            pkgwriter.write(bnp[0] + '/' + bnp + '\n')
+            koji.ensuredir(os.path.join(self.repodir, bnp[0]))
+            os.symlink(ml_pkg, os.path.join(self.repodir, bnp[0], bnp))
             self.keypaths[bnp] = ml_pkg
 
 
@@ -4638,9 +4640,10 @@ enabled=1
                 fs_missing.add(pkgpath)
             else:
                 bnp = os.path.basename(pkgpath)
-                pkglist.write(bnp + '\n')
+                pkglist.write(bnp[0] + '/' + bnp + '\n')
+                koji.ensuredir(os.path.join(self.repodir, bnp[0]))
                 self.keypaths[bnp] = pkgpath
-                os.symlink(pkgpath, os.path.join(self.repodir, bnp))
+                os.symlink(pkgpath, os.path.join(self.repodir, bnp[0], bnp))
         pkglist.close()
         if len(fs_missing) > 0:
             raise koji.GenericError('Packages missing from the filesystem:\n' +

--- a/builder/kojid
+++ b/builder/kojid
@@ -36,13 +36,13 @@ from koji.daemon import incremental_upload, log_output, TaskManager, SCM
 from koji.tasks import ServerExit, ServerRestart, BaseTaskHandler, MultiPlatformTask
 from koji.util import parseStatus, isSuccess, dslice, dslice_ex
 import multilib
-import multilib.fakepo
 import os
 import pwd
 import grp
 import random
 import re
 import rpm
+import rpmUtils.arch
 import shutil
 import signal
 import smtplib
@@ -62,6 +62,7 @@ from optparse import OptionParser, SUPPRESS_HELP
 from StringIO import StringIO
 from yum import repoMDObject
 import yum.packages
+import yum.Errors
 
 #imports for LiveCD and Appliance handler
 image_enabled = False
@@ -4358,20 +4359,41 @@ class NewSignedRepoTask(BaseTaskHandler):
         if len(task_opts['arch']) == 0:
             raise koji.GenericError('No arches specified nor for the tag!')
         subtasks = {}
+        arch32s = set()
         for arch in task_opts['arch']:
-            # call canonArch?
-            arglist = [tag, repo_id, arch, keys, task_opts] # no mergerepo
+            if not rpmUtils.arch.isMultiLibArch(arch):
+                arch32s.add(arch)
+        for arch in arch32s:
+            # we do 32-bit multilib arches first so the 64-bit ones can
+            # get a task ID and wait for them to complete
+            arglist = [tag, repo_id, arch, keys, task_opts]
             subtasks[arch] = self.session.host.subtask(
                 method='createsignedrepo', arglist=arglist, label=arch,
                 parent=self.id, arch='noarch')
-        # wait for subtasks to finish
-        self.logger.warn("5: %s" % subtasks.values())
-        results = self.wait(subtasks.values(), all=True, failany=True)
-        self.logger.warn("6")
+        if len(subtasks) > 0 and task_opts['multilib']:
+            results = self.wait(subtasks.values(), all=True, failany=True)
+            for arch in arch32s:
+                # move the 32-bit task output to the final resting place
+                # so the 64-bit arches can use it
+                upload, files = results[subtasks[arch]]
+                self.session.host.signedRepoMove(repo_id, upload, files, arch)
+        for arch in task_opts['arch']:
+            # do the other arches
+            if arch not in arch32s:
+                arglist = [tag, repo_id, arch, keys, task_opts]
+                subtasks[arch] = self.session.host.subtask(
+                    method='createsignedrepo', arglist=arglist, label=arch,
+                    parent=self.id, arch='noarch')
+        # wait for 64-bit subtasks to finish
         data = {}
+        results = self.wait(subtasks.values(), all=True, failany=True)
         for (arch, task_id) in subtasks.iteritems():
             data[arch] = results[task_id]
-            self.logger.debug("DEBUG: %r : %r " % (arch, data[arch],))
+            self.logger.debug("DEBUG: %r : %r " % (arch, data[arch]))
+            if arch not in arch32s:
+                # we moved the 32-bit results before, do the 64-bit
+                upload, files = results[subtasks[arch]]
+                self.session.host.signedRepoMove(repo_id, upload, files, arch)
         self.session.host.repoDone(repo_id, data, expire=True, signed=True)
         return 'Signed repository #%s successfully generated' % repo_id
 
@@ -4379,17 +4401,36 @@ class NewSignedRepoTask(BaseTaskHandler):
 class createSignedRepoTask(CreaterepoTask):
     Methods = ['createsignedrepo']
     _taskWeight = 1.5
+
     archmap = {'s390x': 's390', 'ppc64': 'ppc', 'x86_64': 'i686'}
+    compat = {"i386": ("athlon", "i686", "i586", "i486", "i386", "noarch"),
+          "x86_64": ("amd64", "ia32e", "x86_64", "noarch"),
+          "ia64": ("ia64", "noarch"),
+          "ppc": ("ppc", "noarch"),
+          "ppc64": ("ppc64p7", "ppc64pseries", "ppc64iseries", "ppc64", "noarch"),
+          "ppc64le": ("ppc64le", "noarch"),
+          "s390": ("s390", "noarch"),
+          "s390x": ("s390x",  "noarch"),
+          "sparc": ("sparcv9v", "sparcv9", "sparcv8", "sparc", "noarch"),
+          "sparc64": ("sparc64v", "sparc64", "noarch"),
+          "alpha": ("alphaev6", "alphaev56", "alphaev5", "alpha", "noarch"),
+          "arm": ("arm", "armv4l", "armv4tl", "armv5tel", "armv5tejl", "armv6l", "armv7l", "noarch"),
+          "armhfp": ("armv7hl", "armv7hnl", "noarch"),
+          "aarch64": ("aarch64", "noarch"),
+          }
+
+    biarch = {"ppc": "ppc64", "x86_64": "i386", "sparc":
+          "sparc64", "s390x": "s390", "ppc64": "ppc"}
 
     def handler(self, tag, repo_id, arch, keys, opts):
         #arch is the arch of the repo, not the task
-        rinfo = self.session.repoInfo(repo_id, strict=True)
-        if rinfo['state'] != koji.REPO_INIT:
-            raise koji.GenericError, "Repo %(id)s not in INIT state (got %(state)s)" % rinfo
-        self.repo_id = rinfo['id']
+        self.rinfo = self.session.repoInfo(repo_id, strict=True)
+        if self.rinfo['state'] != koji.REPO_INIT:
+            raise koji.GenericError, "Repo %(id)s not in INIT state (got %(state)s)" % self.rinfo
+        self.repo_id = self.rinfo['id']
         self.pathinfo = koji.PathInfo(self.options.topdir)
         groupdata = os.path.join(
-            self.pathinfo.signedrepo(repo_id, rinfo['tag_name']),
+            self.pathinfo.signedrepo(repo_id, self.rinfo['tag_name']),
             'groups', 'comps.xml')
         self.repodir = self.options.topdir # workaround for create_local_repo
         #set up our output dir
@@ -4400,65 +4441,173 @@ class createSignedRepoTask(CreaterepoTask):
                 if not os.path.exists(path):
                     raise koji.GenericError(
                         'drpm path %s does not exist!' % path)
-        pkglist = self.make_pkglist(tag, arch, keys, opts)
-        uploadpath = self.getUploadDir()
-        self.session.uploadWrapper(pkglist, uploadpath,
-            os.path.basename(pkglist))
-        if os.path.getsize(pkglist) == 0:
-            pkglist = None
+        self.uploadpath = self.getUploadDir()
+        self.pkglist = self.make_pkglist(tag, arch, keys, opts)
+        if opts['multilib'] and rpmUtils.arch.isMultiLibArch(arch):
+            self.do_multilib(arch, self.archmap[arch], opts['multilib'])
+        self.logger.debug('package list is %s' % self.pkglist)
+        self.session.uploadWrapper(self.pkglist, self.uploadpath,
+            os.path.basename(self.pkglist))
+        if os.path.getsize(self.pkglist) == 0:
+            self.pkglist = None
         if len(opts['delta']) > 0:
             do_drpms = True
         else:
             do_drpms = False
-        self.create_local_repo(rinfo, arch, pkglist, groupdata, opts['delta'],
-            drpms=do_drpms, baseurl='toplink')
-        if pkglist is None:
+        self.create_local_repo(self.rinfo, arch, self.pkglist, groupdata,
+            opts['delta'], drpms=do_drpms, baseurl='toplink')
+        if self.pkglist is None:
             fo = file(os.path.join(self.datadir, "EMPTY_REPO"), 'w')
             fo.write("This repo is empty because its tag has no content for this arch\n")
             fo.close()
         files = ['pkglist']
         for f in os.listdir(self.datadir):
             files.append(f)
-            self.session.uploadWrapper('%s/%s' % (self.datadir, f), uploadpath, f)
+            self.session.uploadWrapper('%s/%s' % (self.datadir, f),
+                self.uploadpath, f)
         if opts['delta']:
             ddir = os.path.join(self.outdir, 'drpms')
             for f in os.listdir(ddir):
                 files.append(f)
-                self.session.uploadWrapper('%s/%s' % (ddir, f), uploadpath, f)
-        return [uploadpath, files]
+                self.session.uploadWrapper('%s/%s' % (ddir, f),
+                    self.uploadpath, f)
+        return [self.uploadpath, files]
 
-    def get_po(self, rpmpath):
-        """create a fake yum-like package object given an rpminfo dictionary"""
-        po = yum.packages.YumLocalPackage(filename=rpmpath)
-        return multilib.fakepo.FakePackageObject(po=po)
+    def do_multilib(self, arch, ml_arch, conf):
+        self.repo_id = self.rinfo['id']
+        pathinfo = koji.PathInfo(self.options.topdir)
+        repodir = pathinfo.signedrepo(self.rinfo['id'], self.rinfo['tag_name'])
+        archdir = os.path.join(repodir, arch)
+        mldir = os.path.join(repodir, koji.canonArch(ml_arch))
+        ml_true = set()
+        ml_conf = os.path.join(self.pathinfo.work(), conf)
+
+        # step 1: figure out which packages are multlib (should already exist)
+        mlm = multilib.DevelMultilibMethod(ml_conf)
+        fs_missing = set()
+        with open(self.pkglist) as pkglist:
+            for pkg in pkglist:
+                pkg = pkg.strip()
+                rpmpath = self.options.topdir + pkg
+                try:
+                    po = yum.packages.YumLocalPackage(filename=rpmpath)
+                except yum.Errors.MiscError:
+                    self.logger.error('%s is not on the filesystem' % rpmpath)
+                    fs_missing.add(rpmpath)
+                    continue
+                if mlm.select(po) and self.archmap.has_key(arch):
+                    # we need a multilib package to be included
+                    # we assume the same signature level is available
+                    pl_path = pkg.replace(arch, self.archmap[arch])
+                    real_path = rpmpath.replace(arch, self.archmap[arch])
+                    ml_true.add(pl_path)
+                    if not os.path.exists(real_path):
+                        self.logger.error('%s (multilib) is not on the filesystem' % ml_path)
+                        fs_missing.add(real_path)
+
+        # step 2: set up architectures for yum configuration
+        self.logger.info("Resolving multilib for %s using method devel" % arch)
+        yumbase = yum.YumBase()
+        yumbase.verbose_logger.setLevel(logging.ERROR)
+        yumdir = os.path.join(self.workdir, 'yum')
+        # TODO: unwind this arch mess
+        archlist = (arch, 'noarch')
+        transaction_arch = arch
+        archlist = archlist + self.compat[self.biarch[arch]]
+        best_compat = self.compat[self.biarch[arch]][0]
+        if rpmUtils.arch.archDifference(best_compat, arch) > 0:
+            transaction_arch = best_compat
+        if hasattr(rpmUtils.arch, 'ArchStorage'):
+            yumbase.preconf.arch = transaction_arch
+        else:
+            rpmUtils.arch.canonArch = transaction_arch
+
+        yconfig = """
+[main]
+debuglevel=2
+pkgpolicy=newest
+exactarch=1
+gpgcheck=0
+reposdir=/dev/null
+cachedir=/yumcache
+installroot=%s
+logfile=/yum.log
+
+[koji-%s]
+name=koji multilib task
+baseurl=file://%s
+enabled=1
+
+""" % (yumdir, self.id, mldir)
+        os.makedirs(os.path.join(yumdir, "yumcache"))
+        os.makedirs(os.path.join(yumdir, 'var/lib/rpm'))
+
+        # step 3: proceed with yum config and set up
+        yconfig_path = os.path.join(yumdir, 'yum.conf-koji-%s' % arch)
+        f = open(yconfig_path, 'w')
+        f.write(yconfig)
+        f.close()
+        self.session.uploadWrapper(yconfig_path, self.uploadpath,
+            os.path.basename(yconfig_path))
+        yumbase.doConfigSetup(fn=yconfig_path)
+        yumbase.conf.cache = 0
+        yumbase.doRepoSetup()
+        yumbase.doTsSetup()
+        yumbase.doRpmDBSetup()
+        # we trust Koji's files, so skip verifying sigs and digests
+        yumbase.ts.pushVSFlags(
+            (rpm._RPMVSF_NOSIGNATURES | rpm._RPMVSF_NODIGESTS))
+        yumbase.doSackSetup(archlist=archlist, thisrepo='koji-%s' % arch)
+        yumbase.doSackFilelistPopulate()
+        for pkg in ml_true:
+            # TODO: store packages by first letter
+            # ppath = os.path.join(pkgdir, pkg.name[0].lower(), pname)
+            real_path = self.options.topdir + pkg
+            po = yum.packages.YumLocalPackage(filename=real_path)
+            yumbase.tsInfo.addInstall(po)
+
+        # step 4: execute yum transaction to get dependencies
+        self.logger.info("Resolving depenencies for arch %s" % arch)
+        rc, errors = yumbase.resolveDeps()
+        ml_needed = set()
+        for f in yumbase.tsInfo.getMembers():
+            dep_path = os.path.join(mldir, os.path.basename(f.po.localPkg()))
+            rel_path = dep_path.replace(self.options.topdir, '')
+            ml_needed.add(rel_path)
+            self.logger.debug("added %s" % rel_path)
+            if not os.path.exists(dep_path):
+                self.logger.error('%s (multilib dep) not on filesystem' % dep_path)
+                fs_missing.add(dep_path)
+        self.logger.info('yum return code: %s' % rc)
+        if not rc:
+            self.logger.error('yum depsolve was unsuccessful')
+            raise koji.GenericError(errors)
+        if len(fs_missing) > 0:
+            raise koji.GenericError('multilib packages missing:\n' +
+                '\n'.join(fs_missing))
+
+        # step 5: add dependencies to our package list
+        pkgwriter = open(self.pkglist, 'a')
+        for ml_pkg in ml_needed:
+            pkgwriter.write(ml_pkg + '\n')
 
     def make_pkglist(self, tag_id, arch, keys, opts):
 
-        def write_pkg(pkgpath):
-            self.logger.info('incoming: %s' % pkgpath)
-            self.logger.info('topdir: %s' % self.options.topdir)
-            newpath = pkgpath.replace(self.options.topdir, '') + '\n'
-            self.logger.info('outgoing: %s' % newpath)
-            pkglist.write(newpath)
-
         # Need to pass event_id because even though this is a single trans,
         # it is possible to see the results of other committed transactions
-        rpm_iter, builds = self.session.listTaggedRPMS(tag_id,
-            event=opts['event'], arch=arch,
-            inherit=opts['inherit'], rpmsigs=True)
-        rpms = list(rpm_iter)
-        if opts['multilib']:
-            mlm = multilib.MultilibDevelMethod(opts['multilib'])
-        else:
-            # this method always returns False, no multilib packages added
-            mlm = multilib.NoMultilibMethod(opts['multilib'])
-        need = set(['%(name)s-%(version)s-%(release)s.%(arch)s.rpm' % r for r in rpms])
-        #get build dirs
+        rpms = []
         builddirs = {}
-        for build in builds:
-            builddirs[build['id']] = self.pathinfo.build(build)
+        for a in (arch, 'noarch'):
+            rpm_iter, builds = self.session.listTaggedRPMS(tag_id,
+                event=opts['event'], arch=a,
+                inherit=opts['inherit'], rpmsigs=True)
+            for build in builds:
+                builddirs[build['id']] = self.pathinfo.build(build)
+            rpms += list(rpm_iter)
+        #get build dirs
+        need = set(['%(name)s-%(version)s-%(release)s.%(arch)s.rpm' % r for r in rpms])
         #generate pkglist files
-        archdir = os.path.join(self.outdir, arch)
+        archdir = os.path.join(self.outdir, koji.canonArch(arch))
         koji.ensuredir(archdir)
         pkgfile = os.path.join(archdir, 'pkglist')
         pkglist = file(pkgfile, 'w')
@@ -4479,6 +4628,7 @@ class createSignedRepoTask(CreaterepoTask):
                     continue
             preferred[rpminfo['id']] = rpminfo
         seen = set()
+        fs_missing = set()
         for rpminfo in preferred.values():
             if rpminfo['sigkey'] == '':
                 # we're taking an unsigned rpm (--allow-unsigned)
@@ -4488,21 +4638,19 @@ class createSignedRepoTask(CreaterepoTask):
                 pkgpath = '%s/%s' % (builddirs[rpminfo['build_id']],
                     self.pathinfo.signed(rpminfo, rpminfo['sigkey']))
             seen.add(os.path.basename(pkgpath))
-            po = self.get_po(pkgpath)
-            mlppath = None # multilib package path
-            if mlm.select(po):
-                # we need a multilib package to be included
-                # we assume the same signature level is available
-                write_pkg(pkgpath.replace(arch, archmap[arch]))
-            write_pkg(pkgpath)
+            pkglist.write(pkgpath.replace(self.options.topdir, '') + '\n')
+            if not os.path.exists(pkgpath):
+                fs_missing.add(pkgpath)
         pkglist.close()
+        if len(fs_missing) > 0:
+            raise koji.GenericError('Packages missing from the filesystem:\n' +
+                '\n'.join(fs_missing))
         if not opts['skip']:
             missing = list(need - seen)
             if len(missing) != 0:
                 missing.sort()
                 raise koji.GenericError('Unsigned packages found: ' +
                     '\n'.join(missing))
-        # TODO: needs to not be in /var/tmp...
         return pkgfile
 
 

--- a/builder/kojid
+++ b/builder/kojid
@@ -4342,10 +4342,9 @@ class NewSignedRepoTask(BaseTaskHandler):
     Methods = ['signedRepo']
     _taskWeight = 0.1
 
-    def handler(self, tag, repo_id):
+    def handler(self, tag, repo_id, task_opts):
         # TODO: remember to use an event here
         tinfo = self.session.getTag(tag, strict=True)
-        kwargs = {}
         path = koji.pathinfo.signedrepo(repo_id, tinfo['name'])
         if not os.path.isdir(path):
             raise koji.GenericError, "Repo directory missing: %s" % path

--- a/builder/kojid
+++ b/builder/kojid
@@ -35,6 +35,8 @@ import logging.handlers
 from koji.daemon import incremental_upload, log_output, TaskManager, SCM
 from koji.tasks import ServerExit, ServerRestart, BaseTaskHandler, MultiPlatformTask
 from koji.util import parseStatus, isSuccess, dslice, dslice_ex
+import multilib
+import multilib.fakepo
 import os
 import pwd
 import grp
@@ -59,6 +61,7 @@ from gzip import GzipFile
 from optparse import OptionParser, SUPPRESS_HELP
 from StringIO import StringIO
 from yum import repoMDObject
+import yum.packages
 
 #imports for LiveCD and Appliance handler
 image_enabled = False
@@ -4211,9 +4214,8 @@ class NewRepoTask(BaseTaskHandler):
         else:
             oldrepo = self.session.getRepo(tinfo['id'], state=koji.REPO_READY)
         subtasks = {}
-        opts = {'do_external': True, 'deltas': False}
         for arch in arches:
-            arglist = [repo_id, arch, oldrepo, opts]
+            arglist = [repo_id, arch, oldrepo]
             subtasks[arch] = self.session.host.subtask(method='createrepo',
                                                        arglist=arglist,
                                                        label=arch,
@@ -4236,17 +4238,14 @@ class CreaterepoTask(BaseTaskHandler):
     Methods = ['createrepo']
     _taskWeight = 1.5
 
-    def getRepoPath(self, repo_id, tag):
-        return self.pathinfo.repo(repo_id, tag)
-
-    def handler(self, repo_id, arch, oldrepo, opts):
+    def handler(self, repo_id, arch, oldrepo):
         #arch is the arch of the repo, not the task
         rinfo = self.session.repoInfo(repo_id, strict=True)
         if rinfo['state'] != koji.REPO_INIT:
             raise koji.GenericError, "Repo %(id)s not in INIT state (got %(state)s)" % rinfo
         self.repo_id = rinfo['id']
         self.pathinfo = koji.PathInfo(self.options.topdir)
-        toprepodir = self.getRepoPath(repo_id, rinfo['tag_name'])
+        toprepodir = self.pathinfo.repo(repo_id, rinfo['tag_name'])
         self.repodir = '%s/%s' % (toprepodir, arch)
         if not os.path.isdir(self.repodir):
             raise koji.GenericError, "Repo directory missing: %s" % self.repodir
@@ -4257,13 +4256,11 @@ class CreaterepoTask(BaseTaskHandler):
         pkglist = os.path.join(self.repodir, 'pkglist')
         if os.path.getsize(pkglist) == 0:
             pkglist = None
-        self.create_local_repo(rinfo, arch, pkglist, groupdata, oldrepo,
-            opts['deltas'])
-        if opts['do_external']:
-            external_repos = self.session.getExternalRepoList(
-                rinfo['tag_id'], event=rinfo['create_event'])
-            if external_repos:
-                self.merge_repos(external_repos, arch, groupdata)
+        self.create_local_repo(rinfo, arch, pkglist, groupdata, oldrepo)
+        external_repos = self.session.getExternalRepoList(
+            rinfo['tag_id'], event=rinfo['create_event'])
+        if external_repos:
+            self.merge_repos(external_repos, arch, groupdata)
         elif pkglist is None:
             fo = file(os.path.join(self.datadir, "EMPTY_REPO"), 'w')
             fo.write("This repo is empty because its tag has no content for this arch\n")
@@ -4274,20 +4271,17 @@ class CreaterepoTask(BaseTaskHandler):
         for f in os.listdir(self.datadir):
             files.append(f)
             self.session.uploadWrapper('%s/%s' % (self.datadir, f), uploadpath, f)
-        if opts['deltas']:
-            ddir = os.path.join(self.outdir, 'drpms')
-            for f in os.listdir(ddir):
-                files.append(f)
-                self.session.uploadWrapper('%s/%s' % (ddir, f), uploadpath, f)
         return [uploadpath, files]
 
-    def create_local_repo(self, rinfo, arch, pkglist, groupdata, oldrepo, drpms):
+    def create_local_repo(self, rinfo, arch, pkglist, groupdata, oldrepo, baseurl=None, drpms=False):
         koji.ensuredir(self.outdir)
         cmd = ['/usr/bin/createrepo', '-vd', '-o', self.outdir]
         if pkglist is not None:
             cmd.extend(['-i', pkglist])
         if os.path.isfile(groupdata):
             cmd.extend(['-g', groupdata])
+        if baseurl:
+            cmd.extend(['-u', baseurl])
         #attempt to recycle repodata from last repo
         if pkglist and oldrepo and self.options.createrepo_update and not drpms:
             # signed repos overload the use of "oldrepo", so the conditional
@@ -4356,44 +4350,161 @@ class NewSignedRepoTask(BaseTaskHandler):
     Methods = ['signedRepo']
     _taskWeight = 0.1
 
-    def handler(self, tag, repo_id, task_opts):
+    def handler(self, tag, repo_id, keys, task_opts):
         tinfo = self.session.getTag(tag, strict=True, event=task_opts['event'])
         path = koji.pathinfo.signedrepo(repo_id, tinfo['name'])
-        if not os.path.isdir(path):
-            raise koji.GenericError, "Repo directory missing: %s" % path
-        arches = []
-        for fn in os.listdir(path):
-            if os.path.isfile("%s/%s/pkglist" % (path, fn)):
-                arches.append(fn)
+        if len(task_opts['arch']) == 0:
+             task_opts['arch'] = tinfo['arches'].split()
+        if len(task_opts['arch']) == 0:
+            raise koji.GenericError('No arches specified nor for the tag!')
         subtasks = {}
-        if task_opts['delta']:
-            make_drpms = True
-            oldrepo = task_opts['delta']
-        else:
-            make_drpms = False
-            oldrepo = None
-        for arch in arches:
-            opts = {'do_external': False, 'deltas': make_drpms}
-            arglist = [repo_id, arch, oldrepo, opts]
+        for arch in task_opts['arch']:
+            # call canonArch?
+            arglist = [tag, repo_id, arch, keys, task_opts] # no mergerepo
             subtasks[arch] = self.session.host.subtask(
                 method='createsignedrepo', arglist=arglist, label=arch,
                 parent=self.id, arch='noarch')
         # wait for subtasks to finish
+        self.logger.warn("5: %s" % subtasks.values())
         results = self.wait(subtasks.values(), all=True, failany=True)
+        self.logger.warn("6")
         data = {}
         for (arch, task_id) in subtasks.iteritems():
             data[arch] = results[task_id]
             self.logger.debug("DEBUG: %r : %r " % (arch, data[arch],))
         self.session.host.repoDone(repo_id, data, expire=True, signed=True)
-        return repo_id, task_opts['event']
+        return 'Signed repository #%s successfully generated' % repo_id
 
 
 class createSignedRepoTask(CreaterepoTask):
     Methods = ['createsignedrepo']
     _taskWeight = 1.5
+    archmap = {'s390x': 's390', 'ppc64': 'ppc', 'x86_64': 'i686'}
 
-    def getRepoPath(self, repo_id, tag):
-        return self.pathinfo.signedrepo(repo_id, tag)
+    def handler(self, tag, repo_id, arch, keys, opts):
+        #arch is the arch of the repo, not the task
+        rinfo = self.session.repoInfo(repo_id, strict=True)
+        if rinfo['state'] != koji.REPO_INIT:
+            raise koji.GenericError, "Repo %(id)s not in INIT state (got %(state)s)" % rinfo
+        self.repo_id = rinfo['id']
+        self.pathinfo = koji.PathInfo(self.options.topdir)
+        groupdata = os.path.join(
+            self.pathinfo.signedrepo(repo_id, rinfo['tag_name']),
+            'groups', 'comps.xml')
+        self.repodir = self.options.topdir # workaround for create_local_repo
+        #set up our output dir
+        self.outdir = '%s/repo' % self.workdir
+        self.datadir = '%s/repodata' % self.outdir
+        if len(opts['delta']) > 0:
+            for path in opts['delta']:
+                if not os.path.exists(path):
+                    raise koji.GenericError(
+                        'drpm path %s does not exist!' % path)
+        pkglist = self.make_pkglist(tag, arch, keys, opts)
+        uploadpath = self.getUploadDir()
+        self.session.uploadWrapper(pkglist, uploadpath,
+            os.path.basename(pkglist))
+        if os.path.getsize(pkglist) == 0:
+            pkglist = None
+        if len(opts['delta']) > 0:
+            do_drpms = True
+        else:
+            do_drpms = False
+        self.create_local_repo(rinfo, arch, pkglist, groupdata, opts['delta'],
+            drpms=do_drpms, baseurl='toplink')
+        if pkglist is None:
+            fo = file(os.path.join(self.datadir, "EMPTY_REPO"), 'w')
+            fo.write("This repo is empty because its tag has no content for this arch\n")
+            fo.close()
+        files = ['pkglist']
+        for f in os.listdir(self.datadir):
+            files.append(f)
+            self.session.uploadWrapper('%s/%s' % (self.datadir, f), uploadpath, f)
+        if opts['delta']:
+            ddir = os.path.join(self.outdir, 'drpms')
+            for f in os.listdir(ddir):
+                files.append(f)
+                self.session.uploadWrapper('%s/%s' % (ddir, f), uploadpath, f)
+        return [uploadpath, files]
+
+    def get_po(self, rpmpath):
+        """create a fake yum-like package object given an rpminfo dictionary"""
+        po = yum.packages.YumLocalPackage(filename=rpmpath)
+        return multilib.fakepo.FakePackageObject(po=po)
+
+    def make_pkglist(self, tag_id, arch, keys, opts):
+
+        def write_pkg(pkgpath):
+            self.logger.info('incoming: %s' % pkgpath)
+            self.logger.info('topdir: %s' % self.options.topdir)
+            newpath = pkgpath.replace(self.options.topdir, '') + '\n'
+            self.logger.info('outgoing: %s' % newpath)
+            pkglist.write(newpath)
+
+        # Need to pass event_id because even though this is a single trans,
+        # it is possible to see the results of other committed transactions
+        rpm_iter, builds = self.session.listTaggedRPMS(tag_id,
+            event=opts['event'], arch=arch,
+            inherit=opts['inherit'], rpmsigs=True)
+        rpms = list(rpm_iter)
+        if opts['multilib']:
+            mlm = multilib.MultilibDevelMethod(opts['multilib'])
+        else:
+            # this method always returns False, no multilib packages added
+            mlm = multilib.NoMultilibMethod(opts['multilib'])
+        need = set(['%(name)s-%(version)s-%(release)s.%(arch)s.rpm' % r for r in rpms])
+        #get build dirs
+        builddirs = {}
+        for build in builds:
+            builddirs[build['id']] = self.pathinfo.build(build)
+        #generate pkglist files
+        archdir = os.path.join(self.outdir, arch)
+        koji.ensuredir(archdir)
+        pkgfile = os.path.join(archdir, 'pkglist')
+        pkglist = file(pkgfile, 'w')
+        preferred = {}
+        if opts['unsigned']:
+            keys.append('') # make unsigned rpms the least preferred
+        for rpminfo in rpms:
+            if rpminfo['sigkey'] == '' and not opts['unsigned']:
+                # skip, this is the unsigned rpminfo
+                continue
+            if rpminfo['sigkey'] not in keys:
+                # skip, not a key we are looking for
+                continue
+            idx = keys.index(rpminfo['sigkey'])
+            if preferred.has_key(rpminfo['id']):
+                if keys.index(preferred[rpminfo['id']]['sigkey']) <= idx:
+                    # key for this is not as preferable as what has been seen
+                    continue
+            preferred[rpminfo['id']] = rpminfo
+        seen = set()
+        for rpminfo in preferred.values():
+            if rpminfo['sigkey'] == '':
+                # we're taking an unsigned rpm (--allow-unsigned)
+                pkgpath = '%s/%s' % (builddirs[rpminfo['build_id']],
+                    self.pathinfo.rpm(rpminfo))
+            else:
+                pkgpath = '%s/%s' % (builddirs[rpminfo['build_id']],
+                    self.pathinfo.signed(rpminfo, rpminfo['sigkey']))
+            seen.add(os.path.basename(pkgpath))
+            po = self.get_po(pkgpath)
+            mlppath = None # multilib package path
+            if mlm.select(po):
+                # we need a multilib package to be included
+                # we assume the same signature level is available
+                write_pkg(pkgpath.replace(arch, archmap[arch]))
+            write_pkg(pkgpath)
+        pkglist.close()
+        if not opts['skip']:
+            missing = list(need - seen)
+            if len(missing) != 0:
+                missing.sort()
+                raise koji.GenericError('Unsigned packages found: ' +
+                    '\n'.join(missing))
+        # TODO: needs to not be in /var/tmp...
+        return pkgfile
+
 
 class WaitrepoTask(BaseTaskHandler):
 

--- a/builder/kojid
+++ b/builder/kojid
@@ -4274,15 +4274,13 @@ class CreaterepoTask(BaseTaskHandler):
             self.session.uploadWrapper('%s/%s' % (self.datadir, f), uploadpath, f)
         return [uploadpath, files]
 
-    def create_local_repo(self, rinfo, arch, pkglist, groupdata, oldrepo, baseurl=None, drpms=False):
+    def create_local_repo(self, rinfo, arch, pkglist, groupdata, oldrepo, drpms=False):
         koji.ensuredir(self.outdir)
         cmd = ['/usr/bin/createrepo', '-vd', '-o', self.outdir]
         if pkglist is not None:
             cmd.extend(['-i', pkglist])
         if os.path.isfile(groupdata):
             cmd.extend(['-g', groupdata])
-        if baseurl:
-            cmd.extend(['-u', baseurl])
         #attempt to recycle repodata from last repo
         if pkglist and oldrepo and self.options.createrepo_update and not drpms:
             # signed repos overload the use of "oldrepo", so the conditional
@@ -4375,8 +4373,9 @@ class NewSignedRepoTask(BaseTaskHandler):
             for arch in arch32s:
                 # move the 32-bit task output to the final resting place
                 # so the 64-bit arches can use it
-                upload, files = results[subtasks[arch]]
-                self.session.host.signedRepoMove(repo_id, upload, files, arch)
+                upload, files, keypaths = results[subtasks[arch]]
+                self.session.host.signedRepoMove(
+                    repo_id, upload, files, arch, keypaths)
         for arch in task_opts['arch']:
             # do the other arches
             if arch not in arch32s:
@@ -4392,8 +4391,9 @@ class NewSignedRepoTask(BaseTaskHandler):
             self.logger.debug("DEBUG: %r : %r " % (arch, data[arch]))
             if arch not in arch32s:
                 # we moved the 32-bit results before, do the 64-bit
-                upload, files = results[subtasks[arch]]
-                self.session.host.signedRepoMove(repo_id, upload, files, arch)
+                upload, files, keypaths = results[subtasks[arch]]
+                self.session.host.signedRepoMove(
+                    repo_id, upload, files, arch, keypaths)
         self.session.host.repoDone(repo_id, data, expire=True, signed=True)
         return 'Signed repository #%s successfully generated' % repo_id
 
@@ -4432,10 +4432,12 @@ class createSignedRepoTask(CreaterepoTask):
         groupdata = os.path.join(
             self.pathinfo.signedrepo(repo_id, self.rinfo['tag_name']),
             'groups', 'comps.xml')
-        self.repodir = self.options.topdir # workaround for create_local_repo
         #set up our output dir
-        self.outdir = '%s/repo' % self.workdir
-        self.datadir = '%s/repodata' % self.outdir
+        self.repodir = '%s/repo' % self.workdir
+        koji.ensuredir(self.repodir)
+        self.outdir = self.repodir # workaround create_local_repo use
+        self.datadir = '%s/repodata' % self.repodir
+        self.keypaths = {}
         if len(opts['delta']) > 0:
             for path in opts['delta']:
                 if not os.path.exists(path):
@@ -4455,7 +4457,7 @@ class createSignedRepoTask(CreaterepoTask):
         else:
             do_drpms = False
         self.create_local_repo(self.rinfo, arch, self.pkglist, groupdata,
-            opts['delta'], drpms=do_drpms, baseurl='toplink')
+            opts['delta'], drpms=do_drpms)
         if self.pkglist is None:
             fo = file(os.path.join(self.datadir, "EMPTY_REPO"), 'w')
             fo.write("This repo is empty because its tag has no content for this arch\n")
@@ -4466,20 +4468,19 @@ class createSignedRepoTask(CreaterepoTask):
             self.session.uploadWrapper('%s/%s' % (self.datadir, f),
                 self.uploadpath, f)
         if opts['delta']:
-            ddir = os.path.join(self.outdir, 'drpms')
+            ddir = os.path.join(self.repodir, 'drpms')
             for f in os.listdir(ddir):
                 files.append(f)
                 self.session.uploadWrapper('%s/%s' % (ddir, f),
                     self.uploadpath, f)
-        return [self.uploadpath, files]
+        return [self.uploadpath, files, self.keypaths]
 
     def do_multilib(self, arch, ml_arch, conf):
         self.repo_id = self.rinfo['id']
         pathinfo = koji.PathInfo(self.options.topdir)
         repodir = pathinfo.signedrepo(self.rinfo['id'], self.rinfo['tag_name'])
-        archdir = os.path.join(repodir, arch)
         mldir = os.path.join(repodir, koji.canonArch(ml_arch))
-        ml_true = set()
+        ml_true = set() # multilib packages we need to include before depsolve
         ml_conf = os.path.join(self.pathinfo.work(), conf)
 
         # step 1: figure out which packages are multlib (should already exist)
@@ -4487,22 +4488,17 @@ class createSignedRepoTask(CreaterepoTask):
         fs_missing = set()
         with open(self.pkglist) as pkglist:
             for pkg in pkglist:
-                pkg = pkg.strip()
-                rpmpath = self.options.topdir + pkg
-                try:
-                    po = yum.packages.YumLocalPackage(filename=rpmpath)
-                except yum.Errors.MiscError:
-                    self.logger.error('%s is not on the filesystem' % rpmpath)
-                    fs_missing.add(rpmpath)
-                    continue
+                ppath = os.path.join(self.repodir, pkg.strip())
+                po = yum.packages.YumLocalPackage(filename=ppath)
                 if mlm.select(po) and self.archmap.has_key(arch):
                     # we need a multilib package to be included
                     # we assume the same signature level is available
-                    pl_path = pkg.replace(arch, self.archmap[arch])
-                    real_path = rpmpath.replace(arch, self.archmap[arch])
-                    ml_true.add(pl_path)
+                    pl_path = pkg.replace(arch, self.archmap[arch]).strip()
+                    # assume this exists in the task results for the ml arch
+                    real_path = os.path.join(mldir, pl_path)
+                    ml_true.add(real_path)
                     if not os.path.exists(real_path):
-                        self.logger.error('%s (multilib) is not on the filesystem' % ml_path)
+                        self.logger.error('%s (multilib) is not on the filesystem' % real_path)
                         fs_missing.add(real_path)
 
         # step 2: set up architectures for yum configuration
@@ -4562,8 +4558,7 @@ enabled=1
         for pkg in ml_true:
             # TODO: store packages by first letter
             # ppath = os.path.join(pkgdir, pkg.name[0].lower(), pname)
-            real_path = self.options.topdir + pkg
-            po = yum.packages.YumLocalPackage(filename=real_path)
+            po = yum.packages.YumLocalPackage(filename=pkg)
             yumbase.tsInfo.addInstall(po)
 
         # step 4: execute yum transaction to get dependencies
@@ -4572,9 +4567,8 @@ enabled=1
         ml_needed = set()
         for f in yumbase.tsInfo.getMembers():
             dep_path = os.path.join(mldir, os.path.basename(f.po.localPkg()))
-            rel_path = dep_path.replace(self.options.topdir, '')
-            ml_needed.add(rel_path)
-            self.logger.debug("added %s" % rel_path)
+            ml_needed.add(dep_path)
+            self.logger.debug("added %s" % dep_path)
             if not os.path.exists(dep_path):
                 self.logger.error('%s (multilib dep) not on filesystem' % dep_path)
                 fs_missing.add(dep_path)
@@ -4589,7 +4583,11 @@ enabled=1
         # step 5: add dependencies to our package list
         pkgwriter = open(self.pkglist, 'a')
         for ml_pkg in ml_needed:
-            pkgwriter.write(ml_pkg + '\n')
+            bnp = os.path.basename(ml_pkg)
+            pkgwriter.write(bnp + '\n')
+            os.symlink(ml_pkg, os.path.join(self.repodir, bnp))
+            self.keypaths[bnp] = ml_pkg
+
 
     def make_pkglist(self, tag_id, arch, keys, opts):
 
@@ -4607,9 +4605,7 @@ enabled=1
         #get build dirs
         need = set(['%(name)s-%(version)s-%(release)s.%(arch)s.rpm' % r for r in rpms])
         #generate pkglist files
-        archdir = os.path.join(self.outdir, koji.canonArch(arch))
-        koji.ensuredir(archdir)
-        pkgfile = os.path.join(archdir, 'pkglist')
+        pkgfile = os.path.join(self.repodir, 'pkglist')
         pkglist = file(pkgfile, 'w')
         preferred = {}
         if opts['unsigned']:
@@ -4638,9 +4634,13 @@ enabled=1
                 pkgpath = '%s/%s' % (builddirs[rpminfo['build_id']],
                     self.pathinfo.signed(rpminfo, rpminfo['sigkey']))
             seen.add(os.path.basename(pkgpath))
-            pkglist.write(pkgpath.replace(self.options.topdir, '') + '\n')
             if not os.path.exists(pkgpath):
                 fs_missing.add(pkgpath)
+            else:
+                bnp = os.path.basename(pkgpath)
+                pkglist.write(bnp + '\n')
+                self.keypaths[bnp] = pkgpath
+                os.symlink(pkgpath, os.path.join(self.repodir, bnp))
         pkglist.close()
         if len(fs_missing) > 0:
             raise koji.GenericError('Packages missing from the filesystem:\n' +

--- a/builder/kojid
+++ b/builder/kojid
@@ -4235,14 +4235,17 @@ class CreaterepoTask(BaseTaskHandler):
     Methods = ['createrepo']
     _taskWeight = 1.5
 
-    def handler(self, repo_id, arch, oldrepo):
+    def getRepoPath(self, repo_id, tag):
+        return self.pathinfo.repo(repo_id, tag)
+
+    def handler(self, repo_id, arch, oldrepo, do_external):
         #arch is the arch of the repo, not the task
         rinfo = self.session.repoInfo(repo_id, strict=True)
         if rinfo['state'] != koji.REPO_INIT:
             raise koji.GenericError, "Repo %(id)s not in INIT state (got %(state)s)" % rinfo
         self.repo_id = rinfo['id']
         self.pathinfo = koji.PathInfo(self.options.topdir)
-        toprepodir = self.pathinfo.repo(repo_id, rinfo['tag_name'])
+        toprepodir = self.getRepoPath(repo_id, rinfo['tag_name'])
         self.repodir = '%s/%s' % (toprepodir, arch)
         if not os.path.isdir(self.repodir):
             raise koji.GenericError, "Repo directory missing: %s" % self.repodir
@@ -4256,7 +4259,7 @@ class CreaterepoTask(BaseTaskHandler):
         self.create_local_repo(rinfo, arch, pkglist, groupdata, oldrepo)
 
         external_repos = self.session.getExternalRepoList(rinfo['tag_id'], event=rinfo['create_event'])
-        if external_repos:
+        if external_repos and do_external:
             self.merge_repos(external_repos, arch, groupdata)
         elif pkglist is None:
             fo = file(os.path.join(self.datadir, "EMPTY_REPO"), 'w')
@@ -4333,6 +4336,45 @@ class CreaterepoTask(BaseTaskHandler):
         if not isSuccess(status):
             raise koji.GenericError, 'failed to merge repos: %s' \
                 % parseStatus(status, ' '.join(cmd))
+
+
+class NewSignedRepoTask(BaseTaskHandler):
+    Methods = ['signedRepo']
+    _taskWeight = 0.1
+
+    def handler(self, repo_id, tag):
+        # TODO: remember to use an event here
+        tinfo = self.session.getTag(tag, strict=True)
+        kwargs = {}
+        path = koji.pathinfo.signedrepo(repo_id, tinfo['name'])
+        if not os.path.isdir(path):
+            raise koji.GenericError, "Repo directory missing: %s" % path
+        arches = []
+        for fn in os.listdir(path):
+            if os.path.isfile("%s/%s/pkglist" % (path, fn)):
+                arches.append(fn)
+        subtasks = {}
+        for arch in arches:
+            arglist = [repo_id, arch, None, False] # no old repo or external
+            subtasks[arch] = self.session.host.subtask(
+                method='createsignedrepo', arglist=arglist, label=arch,
+                parent=self.id, arch='noarch')
+        # wait for subtasks to finish
+        results = self.wait(subtasks.values(), all=True, failany=True)
+        data = {}
+        for (arch, task_id) in subtasks.iteritems():
+            data[arch] = results[task_id]
+            self.logger.debug("DEBUG: %r : %r " % (arch, data[arch],))
+        self.session.host.repoDone(repo_id, data, expire=True, signed=True)
+        return repo_id
+
+
+class createSignedRepoTask(CreaterepoTask):
+    Methods = ['createsignedrepo']
+    _taskWeight = 1.5
+
+    def getRepoPath(self, repo_id, tag):
+        return self.pathinfo.signedrepo(repo_id, tag)
 
 class WaitrepoTask(BaseTaskHandler):
 

--- a/builder/kojid
+++ b/builder/kojid
@@ -4342,7 +4342,7 @@ class NewSignedRepoTask(BaseTaskHandler):
     Methods = ['signedRepo']
     _taskWeight = 0.1
 
-    def handler(self, repo_id, tag):
+    def handler(self, tag, repo_id):
         # TODO: remember to use an event here
         tinfo = self.session.getTag(tag, strict=True)
         kwargs = {}

--- a/cli/koji
+++ b/cli/koji
@@ -6506,6 +6506,45 @@ def handle_regen_repo(options, session, args):
         session.logout()
         return watch_tasks(session, [task_id], quiet=options.quiet)
 
+def handle_signed_repo(options, session, args):
+    """create a yum repo of GPG signed RPMs"""
+    usage = _("usage: %prog signed-repo [options] tag keyID [keyID...]")
+    usage += _("\n(Specify the --help option for a list of other options)")
+    parser = OptionParser(usage=usage)
+    parser.add_option("--arch", action='append', default=[],
+        help=_("Indicate an architecture to consider. The default is all architectures associated with the given tag. This option may be specified multiple times."))
+    parser.add_option('--multilib', action='store_true', default=False,
+        help=_('Include multilib packages in the repository'))
+    parser.add_option("--noinherit", action='store_true', default=False,
+        help=_('Do not consider tag inheritance'))
+    parser.add_option("--nowait", action='store_true', default=False,
+        help=_('Do not wait for the task to complete'))
+    task_opts, args = parser.parse_args(args)
+    if len(args) < 2:
+        parser.error(_('You must provide a tag and 1 or more GPG key IDs'))
+    activate_session(session)
+    tag = args[0]
+    keys = args[1:]
+    taginfo = session.getTag(tag)
+    if not taginfo:
+        parser.error(_('unknown tag %s' % tag))
+    if len(task_opts.arch) == 0:
+        task_opts.arch = taginfo['arches']
+        if task_opts.arch == None:
+            parser.error(_('No arches given and no arches associated with tag'))
+    else:
+        for a in task_opts.arch:
+            if a not in taginfo['arches']:
+                print _('Warning: %s is not in the list of tag arches' % a)
+    task_id = session.signedRepo(tag, keys, **task_opts)
+    print "Creating signed repo for tag " + tag
+    if _running_in_bg() or task_opts.nowait:
+        return
+    else:
+        session.logout()
+        return watch_tasks(session, [task_id], quiet=options.quiet)
+
+
 def anon_handle_search(options, session, args):
     "Search the system"
     usage = _("usage: %prog search [options] search_type pattern")

--- a/cli/koji
+++ b/cli/koji
@@ -6517,6 +6517,10 @@ def handle_signed_repo(options, session, args):
         help=_('Include multilib packages in the repository'))
     parser.add_option("--noinherit", action='store_true', default=False,
         help=_('Do not consider tag inheritance'))
+    # TODO: accept comps
+    # TODO: accept events
+    # TODO: sources or no?
+    # TODO: latest?
     parser.add_option("--nowait", action='store_true', default=False,
         help=_('Do not wait for the task to complete'))
     task_opts, args = parser.parse_args(args)
@@ -6534,9 +6538,14 @@ def handle_signed_repo(options, session, args):
             parser.error(_('No arches given and no arches associated with tag'))
     else:
         for a in task_opts.arch:
-            if a not in taginfo['arches']:
+            if not taginfo['arches'] or a not in taginfo['arches']:
                 print _('Warning: %s is not in the list of tag arches' % a)
-    task_id = session.signedRepo(tag, keys, **task_opts)
+    opts = {
+        'arch': task_opts.arch,
+        'multilib': task_opts.multilib,
+        'inherit': not task_opts.noinherit
+    }
+    task_id = session.signedRepo(tag, keys, **opts)
     print "Creating signed repo for tag " + tag
     if _running_in_bg() or task_opts.nowait:
         return

--- a/cli/koji
+++ b/cli/koji
@@ -6520,14 +6520,13 @@ def handle_signed_repo(options, session, args):
     parser.add_option('--comps', help='Include a comps file in the repodata')
     parser.add_option('--delta-rpms', metavar='PATH',default=[],
         action='append',
-        help=_('Create delta-rpms. PATH points to (older) rpms to generate against. May be specified multiple times.'))
+        help=_('Create delta-rpms. PATH points to (older) rpms to generate against. May be specified multiple times. These have to be reachable by the builder too, so the path needs to reach shared storage.'))
     parser.add_option('--event', type='int',
         help=_('create a signed repository based on a Brew event'))
-    parser.add_option('--multilib', action='store_true', default=False,
-        help=_('Include multilib packages in the repository'))
+    parser.add_option('--multilib', action='store_true', default=None,
+        help=_('Include multilib packages in the repository using a config'))
     parser.add_option("--noinherit", action='store_true', default=False,
         help=_('Do not consider tag inheritance'))
-    # TODO: latest?
     parser.add_option("--nowait", action='store_true', default=False,
         help=_('Do not wait for the task to complete'))
     parser.add_option('--skip-unsigned', action='store_true', default=False,
@@ -6538,13 +6537,27 @@ def handle_signed_repo(options, session, args):
     if task_opts.allow_unsigned and task_opts.skip_unsigned:
         parser.error(_('allow_signed and skip_unsigned are mutually exclusive'))
     activate_session(session)
+    stuffdir = _unique_path('cli-signed')
     if task_opts.comps:
         if not os.path.exists(task_opts.comps):
             parser.error(_('could not find %s' % task_opts.comps))
-        compsdir = _unique_path('cli-signed')
-        session.uploadWrapper(task_opts.comps, compsdir,
+        session.uploadWrapper(task_opts.comps, stuffdir,
             callback=_progress_callback)
-        task_opts.comps = os.path.join(compsdir, os.path.basename(task_opts.comps))
+        task_opts.comps = os.path.join(stuffdir,
+            os.path.basename(task_opts.comps))
+    if len(task_opts.delta_rpms) > 0:
+        for path in task_opts.delta_rpms:
+            if not os.path.exists(path):
+                print _("Warning: %s is not reachable locally. If this" % path)
+                print _("  host does not have access to Koji's shared storage")
+                print _("  this can be ignored.")
+    if task_opts.multilib:
+        if not os.path.exists(task_opts.multilib):
+            parser.error(_('could not find %s' % task_opts.multilib))
+        session.uploadWrapper(task_opts.multilib, stuffdir,
+            callback=_progress_callback)
+        task_opts.comps = os.path.join(stuffdir,
+            os.path.basename(task_opts.multilib))
     tag = args[0]
     keys = args[1:]
     taginfo = session.getTag(tag)

--- a/cli/koji
+++ b/cli/koji
@@ -6523,7 +6523,7 @@ def handle_signed_repo(options, session, args):
         help=_('Create delta-rpms. PATH points to (older) rpms to generate against. May be specified multiple times. These have to be reachable by the builder too, so the path needs to reach shared storage.'))
     parser.add_option('--event', type='int',
         help=_('create a signed repository based on a Brew event'))
-    parser.add_option('--multilib', action='store_true', default=None,
+    parser.add_option('--multilib', default=None,
         help=_('Include multilib packages in the repository using a config'))
     parser.add_option("--noinherit", action='store_true', default=False,
         help=_('Do not consider tag inheritance'))
@@ -6543,6 +6543,7 @@ def handle_signed_repo(options, session, args):
             parser.error(_('could not find %s' % task_opts.comps))
         session.uploadWrapper(task_opts.comps, stuffdir,
             callback=_progress_callback)
+        print
         task_opts.comps = os.path.join(stuffdir,
             os.path.basename(task_opts.comps))
     if len(task_opts.delta_rpms) > 0:
@@ -6551,13 +6552,6 @@ def handle_signed_repo(options, session, args):
                 print _("Warning: %s is not reachable locally. If this" % path)
                 print _("  host does not have access to Koji's shared storage")
                 print _("  this can be ignored.")
-    if task_opts.multilib:
-        if not os.path.exists(task_opts.multilib):
-            parser.error(_('could not find %s' % task_opts.multilib))
-        session.uploadWrapper(task_opts.multilib, stuffdir,
-            callback=_progress_callback)
-        task_opts.comps = os.path.join(stuffdir,
-            os.path.basename(task_opts.multilib))
     tag = args[0]
     keys = args[1:]
     taginfo = session.getTag(tag)
@@ -6571,6 +6565,20 @@ def handle_signed_repo(options, session, args):
         for a in task_opts.arch:
             if not taginfo['arches'] or a not in taginfo['arches']:
                 print _('Warning: %s is not in the list of tag arches' % a)
+    if task_opts.multilib:
+        if not os.path.exists(task_opts.multilib):
+            parser.error(_('could not find %s' % task_opts.multilib))
+        if 'x86_64' in task_opts.arch and not 'i686' in task_opts.arch:
+            parser.error(_('The multilib arch (i686) must be included'))
+        if 's390x' in task_opts.arch and not 's390' in task_opts.arch:
+            parser.error(_('The multilib arch (s390) must be included'))
+        if 'ppc64' in task_opts.arch and not 'ppc' in task_opts.arch:
+            parser.error(_('The multilib arch (ppc) must be included'))
+        session.uploadWrapper(task_opts.multilib, stuffdir,
+            callback=_progress_callback)
+        task_opts.multilib = os.path.join(stuffdir,
+            os.path.basename(task_opts.multilib))
+        print
     try:
         task_opts.arch.remove('noarch') # handled specifically
         task_opts.arch.remove('src') # ditto

--- a/cli/koji
+++ b/cli/koji
@@ -6517,13 +6517,13 @@ def handle_signed_repo(options, session, args):
         help=_("Indicate an architecture to consider. The default is all " +
             "architectures associated with the given tag. This option may " +
             "be specified multiple times."))
+    parser.add_option('--event', type='int',
+        help=_('create a signed repository based on a Brew event'))
     parser.add_option('--multilib', action='store_true', default=False,
         help=_('Include multilib packages in the repository'))
     parser.add_option("--noinherit", action='store_true', default=False,
         help=_('Do not consider tag inheritance'))
     # TODO: accept comps
-    # TODO: accept events
-    # TODO: sources or no?
     # TODO: latest?
     # TODO: delta-rpms ugh
     parser.add_option("--nowait", action='store_true', default=False,
@@ -6556,6 +6556,7 @@ def handle_signed_repo(options, session, args):
         pass
     opts = {
         'arch': task_opts.arch,
+        'event': task_opts.event,
         'multilib': task_opts.multilib,
         'inherit': not task_opts.noinherit,
         'skip': task_opts.skip_unsigned,

--- a/cli/koji
+++ b/cli/koji
@@ -6511,8 +6511,12 @@ def handle_signed_repo(options, session, args):
     usage = _("usage: %prog signed-repo [options] tag keyID [keyID...]")
     usage += _("\n(Specify the --help option for a list of other options)")
     parser = OptionParser(usage=usage)
+    parser.add_option('--allow-unsigned', action='store_true', default=False,
+        help=_('Use unsigned RPMs if none are available with the right key'))
     parser.add_option("--arch", action='append', default=[],
-        help=_("Indicate an architecture to consider. The default is all architectures associated with the given tag. This option may be specified multiple times."))
+        help=_("Indicate an architecture to consider. The default is all " +
+            "architectures associated with the given tag. This option may " +
+            "be specified multiple times."))
     parser.add_option('--multilib', action='store_true', default=False,
         help=_('Include multilib packages in the repository'))
     parser.add_option("--noinherit", action='store_true', default=False,
@@ -6521,11 +6525,16 @@ def handle_signed_repo(options, session, args):
     # TODO: accept events
     # TODO: sources or no?
     # TODO: latest?
+    # TODO: delta-rpms ugh
     parser.add_option("--nowait", action='store_true', default=False,
         help=_('Do not wait for the task to complete'))
+    parser.add_option('--skip-unsigned', action='store_true', default=False,
+        help=_('Skip RPMs not signed with the desired key(s)'))
     task_opts, args = parser.parse_args(args)
     if len(args) < 2:
         parser.error(_('You must provide a tag and 1 or more GPG key IDs'))
+    if task_opts.allow_unsigned and task_opts.skip_unsigned:
+        parser.error(_('allow_signed and skip_unsigned are mutually exclusive'))
     activate_session(session)
     tag = args[0]
     keys = args[1:]
@@ -6540,10 +6549,17 @@ def handle_signed_repo(options, session, args):
         for a in task_opts.arch:
             if not taginfo['arches'] or a not in taginfo['arches']:
                 print _('Warning: %s is not in the list of tag arches' % a)
+    try:
+        task_opts.arch.remove('noarch') # handled specifically
+        task_opts.arch.remove('src') # ditto
+    except ValueError:
+        pass
     opts = {
         'arch': task_opts.arch,
         'multilib': task_opts.multilib,
-        'inherit': not task_opts.noinherit
+        'inherit': not task_opts.noinherit,
+        'skip': task_opts.skip_unsigned,
+        'unsigned': task_opts.allow_unsigned
     }
     task_id = session.signedRepo(tag, keys, **opts)
     print "Creating signed repo for tag " + tag

--- a/cli/koji
+++ b/cli/koji
@@ -6517,6 +6517,7 @@ def handle_signed_repo(options, session, args):
         help=_("Indicate an architecture to consider. The default is all " +
             "architectures associated with the given tag. This option may " +
             "be specified multiple times."))
+    parser.add_option('--comps', help='Include a comps file in the repodata')
     parser.add_option('--delta-rpms', metavar='PATH',default=[],
         action='append',
         help=_('Create delta-rpms. PATH points to (older) rpms to generate against. May be specified multiple times.'))
@@ -6526,7 +6527,6 @@ def handle_signed_repo(options, session, args):
         help=_('Include multilib packages in the repository'))
     parser.add_option("--noinherit", action='store_true', default=False,
         help=_('Do not consider tag inheritance'))
-    # TODO: accept comps
     # TODO: latest?
     parser.add_option("--nowait", action='store_true', default=False,
         help=_('Do not wait for the task to complete'))
@@ -6538,6 +6538,13 @@ def handle_signed_repo(options, session, args):
     if task_opts.allow_unsigned and task_opts.skip_unsigned:
         parser.error(_('allow_signed and skip_unsigned are mutually exclusive'))
     activate_session(session)
+    if task_opts.comps:
+        if not os.path.exists(task_opts.comps):
+            parser.error(_('could not find %s' % task_opts.comps))
+        compsdir = _unique_path('cli-signed')
+        session.uploadWrapper(task_opts.comps, compsdir,
+            callback=_progress_callback)
+        task_opts.comps = os.path.join(compsdir, os.path.basename(task_opts.comps))
     tag = args[0]
     keys = args[1:]
     taginfo = session.getTag(tag)
@@ -6558,6 +6565,7 @@ def handle_signed_repo(options, session, args):
         pass
     opts = {
         'arch': task_opts.arch,
+        'comps': task_opts.comps,
         'event': task_opts.event,
         'delta': task_opts.delta_rpms,
         'multilib': task_opts.multilib,

--- a/cli/koji
+++ b/cli/koji
@@ -6517,6 +6517,9 @@ def handle_signed_repo(options, session, args):
         help=_("Indicate an architecture to consider. The default is all " +
             "architectures associated with the given tag. This option may " +
             "be specified multiple times."))
+    parser.add_option('--delta-rpms', metavar='PATH',default=[],
+        action='append',
+        help=_('Create delta-rpms. PATH points to (older) rpms to generate against. May be specified multiple times.'))
     parser.add_option('--event', type='int',
         help=_('create a signed repository based on a Brew event'))
     parser.add_option('--multilib', action='store_true', default=False,
@@ -6525,7 +6528,6 @@ def handle_signed_repo(options, session, args):
         help=_('Do not consider tag inheritance'))
     # TODO: accept comps
     # TODO: latest?
-    # TODO: delta-rpms ugh
     parser.add_option("--nowait", action='store_true', default=False,
         help=_('Do not wait for the task to complete'))
     parser.add_option('--skip-unsigned', action='store_true', default=False,
@@ -6557,6 +6559,7 @@ def handle_signed_repo(options, session, args):
     opts = {
         'arch': task_opts.arch,
         'event': task_opts.event,
+        'delta': task_opts.delta_rpms,
         'multilib': task_opts.multilib,
         'inherit': not task_opts.noinherit,
         'skip': task_opts.skip_unsigned,

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -100,6 +100,7 @@ CREATE TABLE permissions (
 INSERT INTO permissions (name) VALUES ('admin');
 INSERT INTO permissions (name) VALUES ('build');
 INSERT INTO permissions (name) VALUES ('repo');
+INSERT INTO permissions (name) VALUES ('image');
 INSERT INTO permissions (name) VALUES ('livecd');
 INSERT INTO permissions (name) VALUES ('maven-import');
 INSERT INTO permissions (name) VALUES ('win-import');
@@ -433,7 +434,8 @@ CREATE TABLE repo (
 	id SERIAL NOT NULL PRIMARY KEY,
 	create_event INTEGER NOT NULL REFERENCES events(id) DEFAULT get_event(),
 	tag_id INTEGER NOT NULL REFERENCES tag(id),
-	state INTEGER
+	state INTEGER,
+	signed BOOLEAN DEFAULT 'false'
 ) WITHOUT OIDS;
 
 -- external yum repos

--- a/hub/kojihub.py
+++ b/hub/kojihub.py
@@ -10932,7 +10932,11 @@ class HostExports(object):
             koji.ensuredir(datadir)
             for fn in files:
                 src = "%s/%s/%s" % (workdir,uploadpath, fn)
-                dst = "%s/%s" % (datadir, fn)
+                if fn.endswith('.drpm'):
+                    koji.ensuredir(os.path.join(archdir, 'drpms'))
+                    dst = "%s/drpms/%s" % (archdir, fn)
+                else:
+                    dst = "%s/%s" % (datadir, fn)
                 if not os.path.exists(src):
                     raise koji.GenericError, "uploaded file missing: %s" % src
                 os.link(src, dst)

--- a/hub/kojihub.py
+++ b/hub/kojihub.py
@@ -2430,6 +2430,13 @@ def signed_repo_init(tag, keys, task_opts):
             missing.sort()
             raise koji.GenericError('Unsigned packages found: ' +
                 '\n'.join(missing))
+
+    # handle comps
+    if task_opts['comps']:
+        groupsdir = os.path.join(repodir, 'groups')
+        koji.ensuredir(groupsdir)
+        shutil.copyfile(os.path.join(koji.pathinfo.work(), task_opts['comps']),
+            groupsdir + '/comps.xml')
     koji.plugin.run_callbacks('postRepoInit', tag=tinfo,
         event=task_opts['event'], repo_id=repo_id)
     return repo_id, task_opts['event']

--- a/hub/kojihub.py
+++ b/hub/kojihub.py
@@ -2430,13 +2430,6 @@ def signed_repo_init(tag, keys, task_opts):
             missing.sort()
             raise koji.GenericError('Unsigned packages found: ' +
                 '\n'.join(missing))
-
-    # handle comps
-    if task_opts['comps']:
-        groupsdir = os.path.join(repodir, 'groups')
-        koji.ensuredir(groupsdir)
-        shutil.copyfile(os.path.join(koji.pathinfo.work(), task_opts['comps']),
-            groupsdir + '/comps.xml')
     koji.plugin.run_callbacks('postRepoInit', tag=tinfo,
         event=task_opts['event'], repo_id=repo_id)
     return repo_id, task_opts['event']

--- a/hub/kojihub.py
+++ b/hub/kojihub.py
@@ -10919,9 +10919,11 @@ class HostExports(object):
                 # hardlink the found rpms into the final repodir
                 with open(src) as pkgfile:
                     for pkg in pkgfile:
-                        pkg = pkg.strip()
+                        pkg = os.path.basename(pkg.strip())
                         rpmpath = fullpaths[pkg]
-                        os.link(rpmpath, os.path.join(archdir, os.path.basename(rpmpath)))
+                        bnp = os.path.basename(rpmpath)
+                        koji.ensuredir(os.path.join(archdir, bnp[0]))
+                        os.link(rpmpath, os.path.join(archdir, bnp[0], bnp))
             os.unlink(src)
 
     def isEnabled(self):

--- a/hub/kojihub.py
+++ b/hub/kojihub.py
@@ -2351,7 +2351,7 @@ def signed_repo_init(tag, keys, task_opts):
         task_opts['event'] = _singleValue("SELECT get_event()")
     insert = InsertProcessor('repo')
     insert.set(id=repo_id, create_event=task_opts['event'], tag_id=tag_id,
-        state=state)
+        state=state, signed=True)
     insert.execute()
     repodir = koji.pathinfo.signedrepo(repo_id, tinfo['name'])
     for arch in arches:
@@ -2388,6 +2388,7 @@ def repo_info(repo_id, strict=False):
         ('EXTRACT(EPOCH FROM events.time)','create_ts'),
         ('repo.tag_id', 'tag_id'),
         ('tag.name', 'tag_name'),
+        ('repo.signed', 'signed'),
     )
     q = """SELECT %s FROM repo
     JOIN tag ON tag_id=tag.id
@@ -8855,16 +8856,20 @@ class RootExports(object):
                     taginfo['extra'][key] = ancestor['extra'][key]
         return taginfo
 
-    def getRepo(self,tag,state=None,event=None):
-        if isinstance(tag,int):
+    def getRepo(self, tag, state=None, event=None, signed=False):
+        if isinstance(tag, int):
             id = tag
         else:
-            id = get_tag_id(tag,strict=True)
+            id = get_tag_id(tag, strict=True)
 
-        fields = ['repo.id', 'repo.state', 'repo.create_event', 'events.time', 'EXTRACT(EPOCH FROM events.time)']
-        aliases = ['id', 'state', 'create_event', 'creation_time', 'create_ts']
+        fields = ['repo.id', 'repo.state', 'repo.create_event', 'events.time', 'EXTRACT(EPOCH FROM events.time)', 'repo.signed']
+        aliases = ['id', 'state', 'create_event', 'creation_time', 'create_ts', 'signed']
         joins = ['events ON repo.create_event = events.id']
         clauses = ['repo.tag_id = %(id)i']
+        if signed:
+            clauses.append('repo.signed is true')
+        else:
+            clauses.append('repo.signed is false')
         if event:
             # the repo table doesn't have all the fields of a _config table, just create_event
             clauses.append('create_event <= %(event)i')

--- a/hub/kojihub.py
+++ b/hub/kojihub.py
@@ -8935,7 +8935,7 @@ class RootExports(object):
         """Create a signed-repo task. returns task id"""
         context.session.assertPerm('signed-repo')
         repo_id, event_id = signed_repo_init(tag, keys, task_opts)
-        return make_task('signedRepo', [repo_id, tag], priority=15)
+        return make_task('signedRepo', [tag, repo_id], priority=15)
 
     def newRepo(self, tag, event=None, src=False, debuginfo=False):
         """Create a newRepo task. returns task id"""

--- a/hub/kojihub.py
+++ b/hub/kojihub.py
@@ -2347,13 +2347,15 @@ def signed_repo_init(tag, keys, task_opts):
     for arch in repo_arches:
         arches.add(koji.canonArch(arch))
     repo_id = _singleValue("SELECT nextval('repo_id_seq')")
-    event_id = _singleValue("SELECT get_event()")
+    if not task_opts['event']:
+        task_opts['event'] = _singleValue("SELECT get_event()")
     insert = InsertProcessor('repo')
-    insert.set(id=repo_id, create_event=event_id, tag_id=tag_id, state=state)
+    insert.set(id=repo_id, create_event=task_opts['event'], tag_id=tag_id,
+        state=state)
     insert.execute()
     # Need to pass event_id because even though this is a single transaction,
     # it is possible to see the results of other committed transactions
-    rpm_iter, builds = readTaggedRPMS(tag_id, event=event_id,
+    rpm_iter, builds = readTaggedRPMS(tag_id, event=task_opts['event'],
         inherit=task_opts['inherit'], rpmsigs=True)
     rpms = list(rpm_iter)
     for rpm_copy in list(rpms):
@@ -2428,9 +2430,9 @@ def signed_repo_init(tag, keys, task_opts):
             missing.sort()
             raise koji.GenericError('Unsigned packages found: ' +
                 '\n'.join(missing))
-    koji.plugin.run_callbacks('postRepoInit', tag=tinfo, event=event_id,
-        repo_id=repo_id)
-    return repo_id, event_id
+    koji.plugin.run_callbacks('postRepoInit', tag=tinfo,
+        event=task_opts['event'], repo_id=repo_id)
+    return repo_id, task_opts['event']
 
 
 def repo_set_state(repo_id, state, check=True):

--- a/koji/__init__.py
+++ b/koji/__init__.py
@@ -2372,10 +2372,15 @@ def _taskLabel(taskInfo):
         if taskInfo.has_key('request'):
             tagInfo = taskInfo['request'][0]
             extra = tagInfo['name']
-    elif method in ('createrepo', 'createsignedrepo'):
+    elif method in ('createrepo'):
         if taskInfo.has_key('request'):
             arch = taskInfo['request'][1]
             extra = arch
+    elif method in ('createsignedrepo'):
+        if taskInfo.has_key('request'):
+            repo_id = taskInfo['request'][1]
+            arch = taskInfo['request'][2]
+            extra = '%s, %s' % (repo_id, arch)
     elif method == 'dependantTask':
         if taskInfo.has_key('request'):
             extra = ', '.join([subtask[0] for subtask in taskInfo['request'][1]])

--- a/koji/__init__.py
+++ b/koji/__init__.py
@@ -1537,7 +1537,7 @@ class PathInfo(object):
 
     def signedrepo(self, repo_id, tag):
         """Return the directory with a signed repo lives"""
-        return os.path.join(self.topdir, 'repos', 'signed', tag, repo_id)
+        return os.path.join(self.topdir, 'repos', 'signed', tag, str(repo_id))
 
     def repocache(self,tag_str):
         """Return the directory where a repo belongs"""

--- a/koji/__init__.py
+++ b/koji/__init__.py
@@ -2361,7 +2361,7 @@ def _taskLabel(taskInfo):
         if taskInfo.has_key('request'):
             build = taskInfo['request'][1]
             extra = buildLabel(build)
-    elif method == 'newRepo':
+    elif method in ('newRepo', 'signedRepo'):
         if taskInfo.has_key('request'):
             extra = str(taskInfo['request'][0])
     elif method in ('tagBuild', 'tagNotification'):
@@ -2372,7 +2372,7 @@ def _taskLabel(taskInfo):
         if taskInfo.has_key('request'):
             tagInfo = taskInfo['request'][0]
             extra = tagInfo['name']
-    elif method == 'createrepo':
+    elif method in ('createrepo', 'createsignedrepo'):
         if taskInfo.has_key('request'):
             arch = taskInfo['request'][1]
             extra = arch

--- a/koji/__init__.py
+++ b/koji/__init__.py
@@ -1535,6 +1535,10 @@ class PathInfo(object):
         """Return the directory where a repo belongs"""
         return self.topdir + ("/repos/%(tag_str)s/%(repo_id)s" % locals())
 
+    def signedrepo(self, repo_id, tag):
+        """Return the directory with a signed repo lives"""
+        return os.path.join(self.topdir, 'repos', 'signed', tag, repo_id)
+
     def repocache(self,tag_str):
         """Return the directory where a repo belongs"""
         return self.topdir + ("/repos/%(tag_str)s/cache" % locals())

--- a/util/kojira
+++ b/util/kojira
@@ -134,7 +134,11 @@ class ManagedRepo(object):
                              (self.tag_id, self.repo_id))
             return False
         tag_name = tag_info['name']
-        path = pathinfo.repo(self.repo_id, tag_name)
+        rinfo = self.session.repoInfo(self.repo_id, strict=True)
+        if rinfo['signed']:
+            path = pathinfo.signedrepo(self.repo_id, tag_name)
+        else:
+            path = pathinfo.repo(self.repo_id, tag_name)
         try:
             #also check dir age. We do this because a repo can be created from an older event
             #and should not be removed based solely on that event's timestamp.

--- a/util/kojira
+++ b/util/kojira
@@ -333,40 +333,51 @@ class RepoManager(object):
         finally:
             session.logout()
 
-    def pruneLocalRepos(self):
+    def pruneLocalRepos(self, topdir, timername):
         """Scan filesystem for repos and remove any deleted ones
 
         Also, warn about any oddities"""
         if self.delete_pids:
             #skip
             return
-        self.logger.debug("Scanning filesystem for repos")
-        topdir = "%s/repos" % pathinfo.topdir
+        self.logger.debug("Scanning %s for repos" % topdir)
+        self.logger.debug('max age allowed: %s seconds (from %s)' %
+            (getattr(self.options, timername), timername))
         for tag in os.listdir(topdir):
             tagdir = "%s/%s" % (topdir, tag)
             if not os.path.isdir(tagdir):
+                self.logger.debug("%s is not a directory, skipping" % tagdir)
                 continue
             for repo_id in os.listdir(tagdir):
                 try:
                     repo_id = int(repo_id)
                 except ValueError:
+                    self.logger.debug("%s not an int, skipping" % tagdir)
+                    # This condition is how signed repos are not removed by
+                    # the first call to this method. Although, if someone has
+                    # tags that are just integers, that could be a problem.
                     continue
                 repodir = "%s/%s" % (tagdir, repo_id)
                 if not os.path.isdir(repodir):
+                    self.logger.debug("%s not a directory, skipping" % repodir)
                     continue
                 if self.repos.has_key(repo_id):
                     #we're already managing it, no need to deal with it here
+                    self.logger.debug("seen %s already, skipping" % repodir)
                     continue
                 try:
                     dir_ts = os.stat(repodir).st_mtime
                 except OSError:
                     #just in case something deletes the repo out from under us
+                    self.logger.debug("%s deleted already?!" % repodir)
                     continue
                 rinfo = self.session.repoInfo(repo_id)
                 if rinfo is None:
                     if not self.options.ignore_stray_repos:
                         age = time.time() - dir_ts
-                        if age > self.options.deleted_repo_lifetime:
+                        self.logger.debug("did not expect %s; age: %s" %
+                            (repodir, age))
+                        if age > getattr(self.options, timername):
                             self.logger.info("Removing unexpected directory (no such repo): %s" % repodir)
                             self.rmtree(repodir)
                     continue
@@ -375,11 +386,11 @@ class RepoManager(object):
                     continue
                 if rinfo['state'] in (koji.REPO_DELETED, koji.REPO_PROBLEM):
                     age = time.time() - max(rinfo['create_ts'], dir_ts)
-                    if age > self.options.deleted_repo_lifetime:
+                    self.logger.debug("potential removal candidate: %s; age: %s" % (repodir, age))
+                    if age > getattr(self.options, timername):
                         #XXX should really be called expired_repo_lifetime
                         logger.info("Removing stray repo (state=%s): %s" % (koji.REPO_STATES[rinfo['state']], repodir))
                         self.rmtree(repodir)
-                        pass
 
     def tagUseStats(self, tag_id):
         stats = self.tag_use_stats.get(tag_id)
@@ -632,7 +643,9 @@ def main(options, session):
             repomgr.updateRepos()
             repomgr.checkQueue()
             repomgr.printState()
-            repomgr.pruneLocalRepos()
+            repodir = "%s/repos" % pathinfo.topdir
+            repomgr.pruneLocalRepos(repodir, 'deleted_repo_lifetime')
+            repomgr.pruneLocalRepos(repodir + '/signed', 'signed_repo_lifetime')
             if not curr_chk_thread.isAlive():
                 logger.error("Currency checker thread died. Restarting it.")
                 curr_chk_thread = start_currency_checker(session, repomgr)
@@ -725,6 +738,7 @@ def get_options():
                 'delete_batch_size' : 3,
                 'deleted_repo_lifetime': 7*24*3600,
                 #XXX should really be called expired_repo_lifetime
+                'signed_repo_lifetime': 7*24*3600,
                 'sleeptime' : 15,
                 'cert': '/etc/kojira/client.crt',
                 'ca': '/etc/kojira/clientca.crt',
@@ -733,7 +747,8 @@ def get_options():
     if config.has_section(section):
         int_opts = ('deleted_repo_lifetime', 'max_repo_tasks', 'repo_tasks_limit',
                     'retry_interval', 'max_retries', 'offline_retry_interval',
-                    'max_delete_processes', 'max_repo_tasks_maven', 'delete_batch_size', )
+                    'max_delete_processes', 'max_repo_tasks_maven',
+                    'delete_batch_size', 'signed_repo_lifetime')
         str_opts = ('topdir', 'server', 'user', 'password', 'logfile', 'principal', 'keytab', 'krbservice',
                     'cert', 'ca', 'serverca', 'debuginfo_tags', 'source_tags')
         bool_opts = ('with_src','verbose','debug','ignore_stray_repos', 'offline_retry')

--- a/util/kojira.conf
+++ b/util/kojira.conf
@@ -42,3 +42,12 @@ with_src=no
 
 ;certificate of the CA that issued the HTTP server certificate
 ;serverca = /etc/kojira/serverca.crt
+
+;how soon (in seconds) to clean up expired repositories. 1 week default
+;deleted_repo_lifetime = 604800
+
+;how soon (in seconds) to clean up signed repositories. 1 week default here too
+;signed_repo_lifetime = 604800
+
+;turn on debugging statements in the log
+;debug = false

--- a/www/conf/web.conf
+++ b/www/conf/web.conf
@@ -29,3 +29,8 @@ LibPath = /usr/share/koji-web/lib
 # If False, then the footer will be included as another Kid Template.
 # Defaults to True
 LiteralFooter = True
+
+# Uncommenting this will show python tracebacks in the webUI, but they are the
+# same as what you will see in apache's error_log.
+# Not for production use
+#PythonDebug = True

--- a/www/kojiweb/index.py
+++ b/www/kojiweb/index.py
@@ -616,7 +616,7 @@ def taskinfo(environ, taskID):
         build = server.getBuild(params[1])
         values['destTag'] = destTag
         values['build'] = build
-    elif task['method'] in ('newRepo', 'signedRepo'):
+    elif task['method'] in ('newRepo', 'signedRepo', 'createsignedrepo'):
         tag = server.getTag(params[0])
         values['tag'] = tag
     elif task['method'] == 'tagNotification':

--- a/www/kojiweb/index.py
+++ b/www/kojiweb/index.py
@@ -425,6 +425,8 @@ _TASKS = ['build',
           'tagBuild',
           'newRepo',
           'createrepo',
+          'signedRepo',
+          'createsignedrepo',
           'buildNotification',
           'tagNotification',
           'dependantTask',
@@ -435,9 +437,9 @@ _TASKS = ['build',
           'image',
           'createImage']
 # Tasks that can exist without a parent
-_TOPLEVEL_TASKS = ['build', 'buildNotification', 'chainbuild', 'maven', 'chainmaven', 'wrapperRPM', 'winbuild', 'newRepo', 'tagBuild', 'tagNotification', 'waitrepo', 'livecd', 'appliance', 'image']
+_TOPLEVEL_TASKS = ['build', 'buildNotification', 'chainbuild', 'maven', 'chainmaven', 'wrapperRPM', 'winbuild', 'newRepo', 'signedRepo', 'tagBuild', 'tagNotification', 'waitrepo', 'livecd', 'appliance', 'image']
 # Tasks that can have children
-_PARENT_TASKS = ['build', 'chainbuild', 'maven', 'chainmaven', 'winbuild', 'newRepo', 'wrapperRPM', 'livecd', 'appliance', 'image']
+_PARENT_TASKS = ['build', 'chainbuild', 'maven', 'chainmaven', 'winbuild', 'newRepo', 'signedRepo', 'wrapperRPM', 'livecd', 'appliance', 'image']
 
 def tasks(environ, owner=None, state='active', view='tree', method='all', hostID=None, channelID=None, start=None, order='-id'):
     values = _initValues(environ, 'Tasks', 'tasks')
@@ -614,7 +616,7 @@ def taskinfo(environ, taskID):
         build = server.getBuild(params[1])
         values['destTag'] = destTag
         values['build'] = build
-    elif task['method'] == 'newRepo':
+    elif task['method'] in ('newRepo', 'signedRepo'):
         tag = server.getTag(params[0])
         values['tag'] = tag
     elif task['method'] == 'tagNotification':

--- a/www/kojiweb/taskinfo.chtml
+++ b/www/kojiweb/taskinfo.chtml
@@ -216,14 +216,11 @@ $value
         #if $len($params) > 2
         $printOpts($params[2])
         #end if
-        #elif $task.method in ('newRepo', 'signedRepo')
+        #elif $task.method == 'signedRepo'
         <strong>Tag:</strong> <a href="taginfo?tagID=$tag.id">$tag.name</a><br/>
-        #if $task.method == 'signedRepo'
-            <strong>Repo ID:</strong> $params[1]<br/>
-            $printOpts($params[2])
-        #elif $len($params) > 1
-            $printOpts($params[1])
-        #end if
+        <strong>Repo ID:</strong> $params[1]<br/>
+        <strong>Keys:</strong> $printValue(0, $params[2])<br/>
+        $printOpts($params[3])
         #elif $task.method == 'prepRepo'
         <strong>Tag:</strong> <a href="taginfo?tagID=$params[0].id">$params[0].name</a>
         #elif $task.method == 'createrepo'
@@ -238,9 +235,11 @@ $value
             <strong>External Repos:</strong> $printValue(None, [ext['external_repo_name'] for ext in $params[3]])<br/>
         #end if
         #elif $task.method == 'createsignedrepo'
-        <strong>Repo ID:</strong> $params[0]<br/>
-        <strong>Arch:</strong> $params[1]<br/>
-        <strong>Options:</strong> $printMap($params[3], '&nbsp;&nbsp;&nbsp;&nbsp;')
+        <strong>Tag:</strong> <a href="taginfo?tagID=$tag.id">$tag.name</a><br/>
+        <strong>Repo ID:</strong> $params[1]<br/>
+        <strong>Arch:</strong> $printValue(0, $params[2])<br/>
+        <strong>Keys:</strong> $printValue(0, $params[3])<br/>
+        <strong>Options:</strong> $printMap($params[4], '&nbsp;&nbsp;&nbsp;&nbsp;')
         #elif $task.method == 'dependantTask'
         <strong>Dependant Tasks:</strong><br/>
         #for $dep in $deps

--- a/www/kojiweb/taskinfo.chtml
+++ b/www/kojiweb/taskinfo.chtml
@@ -220,6 +220,7 @@ $value
         <strong>Tag:</strong> <a href="taginfo?tagID=$tag.id">$tag.name</a><br/>
         #if $task.method == 'signedRepo'
             <strong>Repo ID:</strong> $params[1]<br/>
+            $printOpts($params[2])
         #elif $len($params) > 1
             $printOpts($params[1])
         #end if

--- a/www/kojiweb/taskinfo.chtml
+++ b/www/kojiweb/taskinfo.chtml
@@ -226,19 +226,21 @@ $value
         #end if
         #elif $task.method == 'prepRepo'
         <strong>Tag:</strong> <a href="taginfo?tagID=$params[0].id">$params[0].name</a>
-        #elif $task.method in ('createrepo', 'createsignedrepo')
+        #elif $task.method == 'createrepo'
         <strong>Repo ID:</strong> $params[0]<br/>
         <strong>Arch:</strong> $params[1]<br/>
-        #if $len($params) > 2
-            #set $oldrepo = $params[2]
-            #if $oldrepo
-                <strong>Old Repo ID:</strong> $oldrepo.id<br/>
-                <strong>Old Repo Creation:</strong> $koji.formatTimeLong($oldrepo.creation_time)<br/>
-            #end if
+        #set $oldrepo = $params[2]
+        #if $oldrepo
+            <strong>Old Repo ID:</strong> $oldrepo.id<br/>
+            <strong>Old Repo Creation:</strong> $koji.formatTimeLong($oldrepo.creation_time)<br/>
         #end if
-        #if $len($params) > 3 and $params[3]
+        #if $len($params) > 4 and $params[4]
             <strong>External Repos:</strong> $printValue(None, [ext['external_repo_name'] for ext in $params[3]])<br/>
         #end if
+        #elif $task.method == 'createsignedrepo'
+        <strong>Repo ID:</strong> $params[0]<br/>
+        <strong>Arch:</strong> $params[1]<br/>
+        <strong>Options:</strong> $printMap($params[3], '&nbsp;&nbsp;&nbsp;&nbsp;')
         #elif $task.method == 'dependantTask'
         <strong>Dependant Tasks:</strong><br/>
         #for $dep in $deps

--- a/www/kojiweb/taskinfo.chtml
+++ b/www/kojiweb/taskinfo.chtml
@@ -216,23 +216,27 @@ $value
         #if $len($params) > 2
         $printOpts($params[2])
         #end if
-        #elif $task.method == 'newRepo'
+        #elif $task.method in ('newRepo', 'signedRepo')
         <strong>Tag:</strong> <a href="taginfo?tagID=$tag.id">$tag.name</a><br/>
-        #if $len($params) > 1
-        $printOpts($params[1])
+        #if $task.method == 'signedRepo'
+            <strong>Repo ID:</strong> $params[1]<br/>
+        #elif $len($params) > 1
+            $printOpts($params[1])
         #end if
         #elif $task.method == 'prepRepo'
         <strong>Tag:</strong> <a href="taginfo?tagID=$params[0].id">$params[0].name</a>
-        #elif $task.method == 'createrepo'
+        #elif $task.method in ('createrepo', 'createsignedrepo')
         <strong>Repo ID:</strong> $params[0]<br/>
         <strong>Arch:</strong> $params[1]<br/>
-        #set $oldrepo = $params[2]
-        #if $oldrepo
-        <strong>Old Repo ID:</strong> $oldrepo.id<br/>
-        <strong>Old Repo Creation:</strong> $koji.formatTimeLong($oldrepo.creation_time)<br/>
+        #if $len($params) > 2
+            #set $oldrepo = $params[2]
+            #if $oldrepo
+                <strong>Old Repo ID:</strong> $oldrepo.id<br/>
+                <strong>Old Repo Creation:</strong> $koji.formatTimeLong($oldrepo.creation_time)<br/>
+            #end if
         #end if
-        #if $len($params) > 3
-        <strong>External Repos:</strong> $printValue(None, [ext['external_repo_name'] for ext in $params[3]])<br/>
+        #if $len($params) > 3 and $params[3]
+            <strong>External Repos:</strong> $printValue(None, [ext['external_repo_name'] for ext in $params[3]])<br/>
         #end if
         #elif $task.method == 'dependantTask'
         <strong>Dependant Tasks:</strong><br/>


### PR DESCRIPTION
This work implements a signed-repo command on the Koji CLI that instructs koji to generate a yum repository containing the RPMs of a given tag that are signed with the correct GPG key(s). All patches are necessary for proper functionality, cherry-picking is not advised.

```
Usage: kojay signed-repo [options] tag keyID [keyID...]
(Specify the --help option for a list of other options)

Options:
  -h, --help           show this help message and exit
  --allow-unsigned     Use unsigned RPMs if none are available with the right
                       key
  --arch=ARCH          Indicate an architecture to consider. The default is
                       all architectures associated with the given tag. This
                       option may be specified multiple times.
  --comps=COMPS        Include a comps file in the repodata
  --delta-rpms=PATH    Create delta-rpms. PATH points to (older) rpms to
                       generate against. May be specified multiple times.
                       These have to be reachable by the builder too, so the
                       path needs to reach shared storage.
  --event=EVENT        create a signed repository based on a Brew event
  --multilib=MULTILIB  Include multilib packages in the repository using a
                       config
  --noinherit          Do not consider tag inheritance
  --nowait             Do not wait for the task to complete
  --skip-unsigned      Skip RPMs not signed with the desired key(s)
```

The output of these tasks yield something like this:
```
/mnt/kojay/repos/signed/your-tag/repo-id
|-- i386
|   |-- finch-2.7.9-25.el6.i686.rpm
|   |-- finch-devel-2.7.9-25.el6.i686.rpm
|   |-- libpurple-2.7.9-25.el6.i686.rpm
|   |-- libpurple-devel-2.7.9-25.el6.i686.rpm
|   |-- pkglist
|   |-- repodata
|   |   |-- 1db4dcd207a464a7b366e81039e8785b70909855e700be13b37228a06026ba63-other.sqlite.bz2
|   |   |-- 26f57582088cb4ea204424b1547277659f5c2e37348a5948970b93d485a6c7e5-primary.xml.gz
|   |   |-- 32e8c7881b05f9b09fbf80d69b5430258300a33dc52ef0a066e37f1f04fd7174-filelists.xml.gz
|   |   |-- 35b086948e11dba1529ac307a071b1132b982ba03519b309fbd6cc1458bb9baa-other.xml.gz
|   |   |-- 9ca040c0d1cd44bc54e6e3e60c247fa57b1501953062dcb57ccaf7242581cfcc-filelists.sqlite.bz2
|   |   |-- a26573478997478e26abb231ba3ba78eccb441b5b785a1547b288671bc4e6816-primary.sqlite.bz2
|   |   `-- repomd.xml
`-- x86_64
    |-- finch-2.7.9-25.el6.i686.rpm
    |-- finch-2.7.9-25.el6.x86_64.rpm
    |-- finch-devel-2.7.9-25.el6.i686.rpm
    |-- finch-devel-2.7.9-25.el6.x86_64.rpm
    |-- libpurple-2.7.9-25.el6.i686.rpm
    |-- libpurple-2.7.9-25.el6.x86_64.rpm
    |-- libpurple-devel-2.7.9-25.el6.i686.rpm
    |-- libpurple-devel-2.7.9-25.el6.x86_64.rpm
    |-- pkglist
    `-- repodata
        |-- 1fb95062e98670740818eb6f038b79d06fcdcd0930f214c6d6d393ba6ec671ac-other.sqlite.bz2
        |-- 31d463e9fe1ff28dbe50094093f6917eae5024ba66b1c47220560607ffaf293e-other.xml.gz
        |-- 4929f0872aa2e2bdc1080b6049c969bccc283bd1dbd1b09b17eec7a47819df74-primary.xml.gz
        |-- 493219a67abe69e593113450bb4e6e92b4630b30a66975cd575d5199e5420cb8-filelists.xml.gz
        |-- cde7a9365c8f5a72510e86855a3757cbbb90f1b212e66689833d3cd8095201e6-filelists.sqlite.bz2
        |-- df8f5dd7ff04acb2721654e81e1f2e9b28952d0968d8f5313ab4b589ed482064-primary.sqlite.bz2
        `-- repomd.xml
```